### PR TITLE
Pug error template

### DIFF
--- a/app.js
+++ b/app.js
@@ -68,7 +68,7 @@ app.use((req, res, next) => {
 
 // error handler
 app.use((err, req, res, next) => {
-	res.send(`<h1>${err.message}</h1><h2>${err.status}</h2><pre>${err.stack}</pre>`);
+	res.render('error', { error: err });
 });
 
 

--- a/views/error.pug
+++ b/views/error.pug
@@ -2,7 +2,11 @@ extends layout.pug
 
 block content
 
-	div
-		h1 #{error.message}
-		h2 #{error.status}
-		p #{error.stack}
+
+  nav.grid-container.portfolio-breadcrumb
+    a(href='/') ← Back
+  article.grid-container(style="margin:0; padding:40px 50px 30px;")
+    h1 #{error.message}
+    p.lead.text-light #{error.status}
+    pre #{error.stack}
+

--- a/views/error.pug
+++ b/views/error.pug
@@ -1,0 +1,8 @@
+extends layout.pug
+
+block content
+
+	div
+		h1 #{error.message}
+		h2 #{error.status}
+		p #{error.stack}


### PR DESCRIPTION
New `render()` method on error handler uses new error.pug template to display error message, status and stack to user.